### PR TITLE
Reduce vendor.js size

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,11 +6,11 @@
   "private": true,
   "scripts": {
     "clean": "ionic-app-scripts clean",
-    "build": "ionic-app-scripts build",
+    "build": "ionic-app-scripts build --prod",
     "lint": "ionic-app-scripts lint",
-    "ionic:build": "ionic-app-scripts build",
+    "ionic:build": "ionic-app-scripts build --prod",
     "ionic:serve": "ionic-app-scripts serve",
-    "postinstall": "ionic-app-scripts build"
+    "postinstall": "ionic-app-scripts build --prod"
   },
   "engines": {
     "node": "10.3.0"

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -9,7 +9,6 @@ import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
 import { HttpModule } from '@angular/http';
 import { MyApp } from './app.component';
-import { PopoverPage } from '../pages/popover/popover';
 import { Validator } from '../providers/validator/validator';
 import { ExecutiveProvider } from '../providers/executive/executive';
 import { EventProvider } from '../providers/event/event';
@@ -26,8 +25,7 @@ export function createTranslateLoader(http: HttpClient) {
 
 @NgModule({
   declarations: [
-    MyApp,
-    PopoverPage
+    MyApp
   ],
   imports: [
     BrowserModule,
@@ -45,8 +43,7 @@ export function createTranslateLoader(http: HttpClient) {
   ],
   bootstrap: [IonicApp],
   entryComponents: [
-    MyApp,
-    PopoverPage,
+    MyApp
   ],
   providers: [
     SplashScreen,


### PR DESCRIPTION
By running with the `--prod` flag, it will reduce the size of the distributables to 20% its original size.